### PR TITLE
Fix Python 3 TypeError when comparing string to None

### DIFF
--- a/requirements_detector/requirement.py
+++ b/requirements_detector/requirement.py
@@ -98,7 +98,7 @@ class DetectedRequirement(object):
         return self.name == other.name and self.url == other.url and self.version_specs == other.version_specs
 
     def __gt__(self, other):
-        return self.name > other.name
+        return self.name or "" > other.name or ""
 
     @staticmethod
     def parse(line, location_defined=None):


### PR DESCRIPTION
Python 3 produces "TypeError: unorderable types" when an attempt is made to compare a string with None, and that can happen in this bit of code, since the "name" attribute can be either a string or None.  This fix ensures the comparison is always between strings.