### PR TITLE
Correct license trove classifier

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -20,8 +20,7 @@ _CLASSIFIERS = (
     'Programming Language :: Python :: 3.3',
     'Programming Language :: Python :: 3.4',
     'Programming Language :: Python :: 3.5',
-    'License :: OSI Approved :: '
-    'GNU General Public License v2 or later (GPLv2+)',
+    'License :: OSI Approved :: MIT License',
 )
 
 


### PR DESCRIPTION
Fixes https://github.com/landscapeio/requirements-detector/issues/7

As discussed in issue ( https://github.com/landscapeio/requirements-detector/issues/7 ), this is [suppose to be MIT]( https://github.com/landscapeio/requirements-detector/issues/7#issuecomment-238766104 ). Here we fix the trove classifier to match.