### PR TITLE
Package license

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,2 @@
 include bin/detect-requirements
+include LICENSE


### PR DESCRIPTION
This ensures the license file is included in any packages like `sdist`s.

Replaces PR ( https://github.com/landscapeio/requirements-detector/pull/10 ).