### PR TITLE
Specify astroid<2.0 to avoid pre-releases

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ if sys.version_info < (2, 7):
     ]
 else:
     _install_requires = [
-        'astroid>=1.4',
+        'astroid>=1.4,<2.0',
     ]
 
 setup(


### PR DESCRIPTION
To work well with the spec of setuptools, the existence of pre-released `astroid==2.0.0.dev0`, and the packages with `'astroid<2.0'` (e.g., pylint), this PR fixes that problem.

Closes #16 