### PR TITLE
Remove comments in requirements before parsing

### DIFF
--- a/requirements_detector/requirement.py
+++ b/requirements_detector/requirement.py
@@ -113,6 +113,12 @@ class DetectedRequirement(object):
         # 7) (-e|--editable) <vcs_url>#egg=<dependency_name>
         line = line.strip()
 
+        # We need to match whitespace + # because url based requirements specify
+        # egg_name after a '#'
+        comment_pos = re.search(r'\s#', line)
+        if comment_pos:
+            line = line[:comment_pos.start()]
+
         # strip the editable flag
         line = re.sub('^(-e|--editable) ', '', line)
 

--- a/tests/test_parsing.py
+++ b/tests/test_parsing.py
@@ -25,6 +25,7 @@ class TestRequirementParsing(TestCase):
         self._test('Django', 'django')
         self._test('celery', 'celery')
 
+
     def test_requirement_with_versions(self):
         self._test('Django==1.5.2', 'django', [('==', '1.5.2')])
         self._test('South>0.8', 'south', [('>', '0.8')])
@@ -52,6 +53,24 @@ class TestRequirementParsing(TestCase):
     def test_editable_vcs_url(self):
         self._test('--editable git+ssh://git@github.com/something/somelib.git#egg=somelib',
                    name='somelib', url='git+ssh://git@github.com/something/somelib.git')
+
+    def test_comments(self):
+        self._test('celery == 0.1 # comment', 'celery', [('==', '0.1')])
+        self._test('celery == 0.1\t# comment', 'celery', [('==', '0.1')])
+        self._test(
+            "somelib == 0.15 # pinned to 0.15 (https://github.com/owner/repo/issues/111)",
+            "somelib",
+            [("==", "0.15")]
+        )
+        self._test(
+            'http://example.com/somelib.tar.gz # comment',
+            url='http://example.com/somelib.tar.gz'
+        )
+        self._test(
+            'http://example.com/somelib.tar.gz#egg=somelib # url comment http://foo.com/bar',
+            name='somelib',
+            url='http://example.com/somelib.tar.gz'
+        )
 
 
 class TestEggFragmentParsing(TestCase):


### PR DESCRIPTION
If a comment in a `requirements.txt` file contains an URL (which is common because users link to issues that explain why they set a requirement constraint), parsing is mislead to use the URL instead of the simple requirement.

I added a step to `DetectedRequirement.parse` that remove comments before parsing.