### PR TITLE
Expose lower level functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,3 +47,12 @@ celery>=2.2,<3
 >>> find_requirements(os.getcwd())
 [DetectedRequirement:Django==1.5.2, DetectedRequirement:South>=0.8, ...]
 ```
+
+
+If you know the relevant file or directory,  you can use `from_requirements_txt`, `from_setup_py` or `from_requirements_dir` directly.
+
+```
+>>> from requirements_detector import from_requirements_txt
+>>> from_requirements_txt("/path/to/requirements.txt")
+[DetectedRequirement:Django==1.5.2, DetectedRequirement:South>=0.8, ...]
+```

--- a/requirements_detector/__init__.py
+++ b/requirements_detector/__init__.py
@@ -1,1 +1,6 @@
-from requirements_detector.detect import find_requirements
+from requirements_detector.detect import (
+    find_requirements,
+    from_requirements_txt,
+    from_requirements_dir,
+    from_setup_py
+)

--- a/requirements_detector/detect.py
+++ b/requirements_detector/detect.py
@@ -8,6 +8,9 @@ from requirements_detector.requirement import DetectedRequirement
 
 
 __all__ = ['find_requirements',
+           'from_requirements_txt',
+           'from_requirements_dir',
+           'from_setup_py',
            'RequirementsNotFound',
            'CouldNotParseRequirements']
 


### PR DESCRIPTION
The parsing logic in the library is valuable. It could be exposed to users that already know the file they want to be parsed as well.

I added `from_requirements_txt`, `from_setup_py` and `from_requirements_dir` to the public API. What do you think?