### PR TITLE
Prevent KeyError when parsing git dependencies in pyproject.toml

### DIFF
--- a/requirements_detector/detect.py
+++ b/requirements_detector/detect.py
@@ -117,7 +117,13 @@ def from_pyproject_toml(toml_file: P) -> List[DetectedRequirement]:
         if name.lower() == "python":
             continue
         if isinstance(spec, dict):
-            spec = spec["version"]
+            if "version" in spec:
+                spec = spec["version"]
+            else:
+                req = DetectedRequirement.parse(f"{name}", toml_file)
+                if req is not None:
+                    requirements.append(req)
+                    continue
         parsed_spec = str(parse_constraint(spec))
         if "," not in parsed_spec and "<" not in parsed_spec and ">" not in parsed_spec and "=" not in parsed_spec:
             parsed_spec = f"=={parsed_spec}"

--- a/tests/detection/test8/pyproject.toml
+++ b/tests/detection/test8/pyproject.toml
@@ -11,6 +11,7 @@ requests = ">=2.25,<2.27"
 twine = "~3.8"
 click = "==8.0.4"
 pyroma = {version = ">=2.4", optional = true}
+mytestdependency = {git = "ssh://git@github.com/MyOrg/MyRepo.git",rev = "1.2.3"}
 
 [tool.poetry.dev-dependencies]
 pytest = "^6.2.4"


### PR DESCRIPTION
A possible fix for https://github.com/landscapeio/requirements-detector/issues/38