### PR TITLE
Retire use of `poetry-semver` and replace functionality with poetry's own version checks

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -705,17 +705,6 @@ importlib-metadata = {version = ">=0.12", markers = "python_version < \"3.8\""}
 dev = ["pre-commit", "tox"]
 testing = ["pytest", "pytest-benchmark"]
 
-[[package]]
-name = "poetry-semver"
-version = "0.1.0"
-description = "A semantic versioning library for Python"
-category = "main"
-optional = false
-python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
-files = [
-    {file = "poetry-semver-0.1.0.tar.gz", hash = "sha256:d809b612aa27b39bf2d0fc9d31b4f4809b0e972646c5f19cfa46c725b7638810"},
-    {file = "poetry_semver-0.1.0-py2.py3-none-any.whl", hash = "sha256:4e6349bd7231cc657f0e1930f7b204e87e33dfd63eef5cac869363969515083a"},
-]
 
 [[package]]
 name = "pre-commit"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ python = ">=3.7,<4.0"
 astroid = "^2.0"
 packaging = ">=21.3"
 toml = "^0.10.2"
-poetry-semver = "^0.1.0"
+poetry = ">=1.4.0" 
 
 [tool.poetry.dev-dependencies]
 tox = "^3.24.5"

--- a/requirements_detector/detect.py
+++ b/requirements_detector/detect.py
@@ -3,7 +3,7 @@ from pathlib import Path
 from typing import List, Union
 
 import toml
-from semver import parse_constraint
+from poetry.core.constraints.version import parse_constraint
 
 from .exceptions import CouldNotParseRequirements, RequirementsNotFound
 from .handle_setup import from_setup_py


### PR DESCRIPTION
Closes #43 

Hey guys, this will retire the use of `poetry-semver` which is now an obsolete package, and archived, and replace it with poetry's own version constraint parsing gubbins. Would be great if you could have a look, and review, since this, after a new release, will allow us to build the conda package correctly with all the deps from conda-forge - very many thanks in advance! :beer: 